### PR TITLE
fix(ci): Make main branch deployment additive

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,7 +83,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build
-          keep_files: false # Overwrite for main branch
+          keep_files: true # Do not overwrite feature branch deployments
           user_name: 'github-actions[bot]'
           user_email: 'github-actions[bot]@users.noreply.github.com'
           commit_message: 'Deploy from ${{ github.sha }}'


### PR DESCRIPTION
This commit corrects the `main` branch deployment logic to prevent it from deleting feature branch previews from GitHub Pages.

The `deploy-main` job was previously configured with `keep_files: false`, which caused it to wipe the entire `gh-pages` branch before deploying the new content.

This has been changed to `keep_files: true`. Now, deployments to the `main` branch will update the files at the root of the site while leaving the `/branch/` directory and its contents untouched. This ensures that feature branch previews persist, as was the original intent.